### PR TITLE
feat: enable AVIF decoding on all platforms

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -2,3 +2,7 @@
   if: runner.os == 'Windows'
   shell: bash
   run: echo C:/Program Files/NASM >> $GITHUB_PATH
+
+- name: Set dav1d build-from-source flag
+  shell: bash
+  run: echo "SYSTEM_DEPS_DAV1D_BUILD_INTERNAL=always" >> $GITHUB_ENV

--- a/.github/workflows/kotlin-bindings.yml
+++ b/.github/workflows/kotlin-bindings.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
+    env:
+      SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -32,11 +34,11 @@ jobs:
 
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install nasm dav1d
+        run: brew install nasm meson ninja
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y nasm
+        run: sudo apt-get update && sudo apt-get install -y nasm meson ninja-build
 
       - name: Build slimg-ffi
         run: cargo build --release -p slimg-ffi

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -15,6 +15,8 @@ jobs:
   build-native:
     name: Build native (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    env:
+      SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
     strategy:
       fail-fast: false
       matrix:
@@ -55,18 +57,18 @@ jobs:
 
       - name: Install system dependencies (macOS native)
         if: runner.os == 'macOS' && matrix.target == 'aarch64-apple-darwin'
-        run: brew install nasm dav1d
+        run: brew install nasm meson ninja
 
       - name: Install system dependencies (macOS x86_64 cross)
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
           # Install x86_64 Homebrew and dependencies for cross-compilation
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 /usr/local/bin/brew install nasm dav1d
+          arch -x86_64 /usr/local/bin/brew install nasm meson ninja
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux' && !matrix.cross
-        run: sudo apt-get update && sudo apt-get install -y nasm
+        run: sudo apt-get update && sudo apt-get install -y nasm meson ninja-build
 
       - name: Install cross (Linux aarch64)
         if: matrix.cross
@@ -80,7 +82,7 @@ jobs:
       - name: Install NASM (Windows)
         if: runner.os == 'Windows'
         shell: bash
-        run: choco install nasm -y
+        run: choco install nasm meson ninja -y
 
       - name: Build with cargo
         if: ${{ !matrix.cross }}
@@ -102,6 +104,8 @@ jobs:
   generate-bindings:
     name: Generate Kotlin bindings
     runs-on: macos-latest
+    env:
+      SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +113,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
-        run: brew install nasm dav1d
+        run: brew install nasm meson ninja
 
       - name: Build slimg-ffi
         run: cargo build --release -p slimg-ffi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,9 @@ jobs:
         if: "runner.os == 'Windows'"
         run: "echo C:/Program Files/NASM >> $GITHUB_PATH"
         shell: "bash"
+      - name: "Set dav1d build-from-source flag"
+        run: "echo \"SYSTEM_DEPS_DAV1D_BUILD_INTERNAL=always\" >> $GITHUB_ENV"
+        shell: "bash"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fast image optimization CLI. Convert, compress, and resize images using modern
 | JPEG   | Yes    | Yes    | MozJPEG encoder for superior compression |
 | PNG    | Yes    | Yes    | OxiPNG optimizer with Zopfli compression |
 | WebP   | Yes    | Yes    | Lossy encoding via libwebp |
-| AVIF   | macOS only | Yes | ravif encoder; decoding requires dav1d (macOS via Homebrew) |
+| AVIF   | Yes    | Yes    | ravif encoder; dav1d decoder (statically linked) |
 | QOI    | Yes    | Yes    | Lossless, fast encode/decode |
 | JPEG XL| Yes    | No     | Decode-only (GPL license restriction) |
 
@@ -48,7 +48,8 @@ cargo install --path cli
 - Rust 1.85+ (edition 2024)
 - C compiler (cc)
 - nasm (for MozJPEG / rav1e assembly optimizations)
-- dav1d (macOS only, for AVIF decoding)
+- meson + ninja (for building dav1d AVIF decoder from source)
+- Set `SYSTEM_DEPS_DAV1D_BUILD_INTERNAL=always` to build dav1d from source
 
 ## Usage
 

--- a/crates/slimg-core/Cargo.toml
+++ b/crates/slimg-core/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Image optimization library — encode, decode, convert, resize"
 
 [dependencies]
-image = "0.25"
+image = { version = "0.25", features = ["avif-native"] }
 mozjpeg = "0.10"
 oxipng = { version = "10", default-features = false, features = ["parallel", "zopfli"] }
 imgref = "1"
@@ -15,9 +15,6 @@ ravif = "0.13"
 rgb = "0.8"
 thiserror = "2"
 webp = { version = "0.3", default-features = false }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-image = { version = "0.25", features = ["avif-native"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/slimg-core/benches/codec_bench.rs
+++ b/crates/slimg-core/benches/codec_bench.rs
@@ -28,13 +28,8 @@ fn encodable_formats() -> Vec<Format> {
 }
 
 /// Formats that support both encoding and decoding (needed for decode benchmarks).
-///
-/// AVIF decoding is only supported on macOS.
 fn decodable_formats() -> Vec<Format> {
-    let mut formats = vec![Format::Jpeg, Format::Png, Format::WebP, Format::Qoi];
-    #[cfg(target_os = "macos")]
-    formats.push(Format::Avif);
-    formats
+    vec![Format::Jpeg, Format::Png, Format::WebP, Format::Qoi, Format::Avif]
 }
 
 fn bench_encode(c: &mut Criterion) {

--- a/crates/slimg-core/benches/pipeline_bench.rs
+++ b/crates/slimg-core/benches/pipeline_bench.rs
@@ -29,16 +29,12 @@ fn pre_encode(image: &ImageData, format: Format, quality: u8) -> Vec<u8> {
 fn bench_convert(c: &mut Criterion) {
     let image = generate_test_image(BENCH_IMAGE_SIZE, BENCH_IMAGE_SIZE);
 
-    let conversions: Vec<(&str, Format, Format)> = {
-        let mut v = vec![
-            ("jpeg_to_webp", Format::Jpeg, Format::WebP),
-            ("png_to_jpeg", Format::Png, Format::Jpeg),
-            ("webp_to_png", Format::WebP, Format::Png),
-        ];
-        #[cfg(target_os = "macos")]
-        v.push(("png_to_avif", Format::Png, Format::Avif));
-        v
-    };
+    let conversions: Vec<(&str, Format, Format)> = vec![
+        ("jpeg_to_webp", Format::Jpeg, Format::WebP),
+        ("png_to_jpeg", Format::Png, Format::Jpeg),
+        ("webp_to_png", Format::WebP, Format::Png),
+        ("png_to_avif", Format::Png, Format::Avif),
+    ];
 
     let pixel_count = (BENCH_IMAGE_SIZE as u64) * (BENCH_IMAGE_SIZE as u64);
     let mut group = c.benchmark_group("convert");
@@ -71,16 +67,12 @@ fn bench_convert(c: &mut Criterion) {
 fn bench_optimize(c: &mut Criterion) {
     let image = generate_test_image(BENCH_IMAGE_SIZE, BENCH_IMAGE_SIZE);
 
-    let formats = {
-        let mut v = vec![
-            ("Jpeg", Format::Jpeg),
-            ("Png", Format::Png),
-            ("WebP", Format::WebP),
-        ];
-        #[cfg(target_os = "macos")]
-        v.push(("Avif", Format::Avif));
-        v
-    };
+    let formats = vec![
+        ("Jpeg", Format::Jpeg),
+        ("Png", Format::Png),
+        ("WebP", Format::WebP),
+        ("Avif", Format::Avif),
+    ];
 
     let mut group = c.benchmark_group("optimize");
 

--- a/crates/slimg-core/src/codec/avif.rs
+++ b/crates/slimg-core/src/codec/avif.rs
@@ -15,26 +15,14 @@ impl Codec for AvifCodec {
     }
 
     fn decode(&self, data: &[u8]) -> Result<ImageData> {
-        #[cfg(target_os = "macos")]
-        {
-            let img = image::load_from_memory_with_format(data, image::ImageFormat::Avif)
-                .map_err(|e| Error::Decode(format!("avif decode: {e}")))?;
+        let img = image::load_from_memory_with_format(data, image::ImageFormat::Avif)
+            .map_err(|e| Error::Decode(format!("avif decode: {e}")))?;
 
-            let rgba = img.to_rgba8();
-            let width = rgba.width();
-            let height = rgba.height();
+        let rgba = img.to_rgba8();
+        let width = rgba.width();
+        let height = rgba.height();
 
-            Ok(ImageData::new(width, height, rgba.into_raw()))
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            let _ = data;
-            Err(Error::Decode(
-                "AVIF decoding is only supported on macOS. Use AVIF as an output format instead."
-                    .to_string(),
-            ))
-        }
+        Ok(ImageData::new(width, height, rgba.into_raw()))
     }
 
     fn encode(&self, image: &ImageData, options: &EncodeOptions) -> Result<Vec<u8>> {
@@ -97,7 +85,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "macos")]
     fn encode_and_decode_roundtrip() {
         let codec = AvifCodec;
         let original = create_test_image(64, 48);

--- a/crates/slimg-core/tests/integration.rs
+++ b/crates/slimg-core/tests/integration.rs
@@ -74,11 +74,7 @@ fn convert_with_resize() {
 fn roundtrip_all_encodable_formats() {
     let image = create_test_image();
 
-    let mut formats = vec![Format::Jpeg, Format::Png, Format::WebP, Format::Qoi];
-
-    // AVIF decoding is only available on macOS (requires dav1d >= 1.3.0, only Homebrew provides it)
-    #[cfg(target_os = "macos")]
-    formats.push(Format::Avif);
+    let formats = vec![Format::Jpeg, Format::Png, Format::WebP, Format::Qoi, Format::Avif];
 
     for fmt in formats {
         let options = PipelineOptions {

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,10 +23,15 @@ github-build-setup = "build-setup.yml"
 # System dependencies required for building
 [dist.dependencies.homebrew]
 nasm = { stage = ["build"] }
-dav1d = { stage = ["build", "run"] }
+meson = { stage = ["build"] }
+ninja = { stage = ["build"] }
 
 [dist.dependencies.apt]
 nasm = '*'
+meson = '*'
+ninja-build = '*'
 
 [dist.dependencies.chocolatey]
 nasm = '*'
+meson = '*'
+ninja = '*'


### PR DESCRIPTION
## Summary

- AVIF 디코딩을 macOS 전용에서 **모든 플랫폼(macOS, Linux, Windows)**으로 확장
- `dav1d` 1.5.0을 소스에서 **정적 빌드**하여 바이너리에 내장 (런타임 의존성 제거)
- `SYSTEM_DEPS_DAV1D_BUILD_INTERNAL=always` 환경변수로 `dav1d-sys` 크레이트의 소스 빌드 활성화

### Changes

- `crates/slimg-core/Cargo.toml`: `avif-native` feature를 전 플랫폼에서 활성화
- `crates/slimg-core/src/codec/avif.rs`: `#[cfg(target_os = "macos")]` 가드 제거
- 테스트/벤치마크: macOS 전용 조건부 컴파일 제거
- CI workflows: `dav1d` 시스템 패키지 → `meson`/`ninja` 빌드 도구 + 환경변수
  - `release.yml` (cargo-dist)
  - `kotlin-bindings.yml`
  - `kotlin-release.yml`
  - `build-setup.yml`
- `dist-workspace.toml`: Homebrew/apt/Chocolatey 의존성 업데이트
- `README.md`: AVIF 지원 상태 및 빌드 요구사항 업데이트

## Test plan

- [ ] macOS CI 빌드 통과 확인
- [ ] Linux CI 빌드 통과 확인 (dav1d 소스 빌드)
- [ ] Windows CI 빌드 통과 확인
- [ ] AVIF roundtrip 테스트 전 플랫폼 통과
- [ ] Kotlin bindings CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)