### PR TITLE
fix(ci): use wrapper header for bindgen CLI in prebuilt workflow

### DIFF
--- a/.github/workflows/build-libjxl-prebuilt.yml
+++ b/.github/workflows/build-libjxl-prebuilt.yml
@@ -157,11 +157,16 @@ jobs:
           SRC_INCLUDE="libjxl-src/lib/include"
           INSTALL_INCLUDE="libjxl-install/include"
 
-          bindgen "${SRC_INCLUDE}/jxl/encode.h" \
-            --header "${SRC_INCLUDE}/jxl/decode.h" \
-            --header "${SRC_INCLUDE}/jxl/types.h" \
-            --header "${SRC_INCLUDE}/jxl/codestream_header.h" \
-            --header "${SRC_INCLUDE}/jxl/color_encoding.h" \
+          # bindgen CLI takes a single header; create a wrapper that includes all needed headers
+          cat > wrapper.h <<HEADER
+          #include "jxl/encode.h"
+          #include "jxl/decode.h"
+          #include "jxl/types.h"
+          #include "jxl/codestream_header.h"
+          #include "jxl/color_encoding.h"
+          HEADER
+
+          bindgen wrapper.h \
             --allowlist-function "JxlEncoderCreate" \
             --allowlist-function "JxlEncoderDestroy" \
             --allowlist-function "JxlEncoderReset" \


### PR DESCRIPTION
## Summary

- bindgen CLI only accepts a single header as positional argument, not `--header` flags
- Create a `wrapper.h` that `#include`s all needed headers instead

Fixes the `Generate bindings.rs` step failure in `build-libjxl-prebuilt.yml`.

## Test plan

- [ ] Re-run `build-libjxl-prebuilt.yml` workflow after merge