### PR TITLE
fix(ci): add clone retry and llvm for prebuilt workflow

### DIFF
--- a/.github/workflows/build-libjxl-prebuilt.yml
+++ b/.github/workflows/build-libjxl-prebuilt.yml
@@ -53,10 +53,21 @@ jobs:
       - name: Checkout libjxl ${{ inputs.libjxl_tag }}
         shell: bash
         run: |
-          git clone --depth 1 --branch "${{ inputs.libjxl_tag }}" \
-            --recurse-submodules --shallow-submodules \
-            https://github.com/libjxl/libjxl.git \
-            libjxl-src
+          for attempt in 1 2 3; do
+            echo "Attempt ${attempt}/3: cloning libjxl..."
+            if git clone --depth 1 --branch "${{ inputs.libjxl_tag }}" \
+                 --recurse-submodules --shallow-submodules \
+                 https://github.com/libjxl/libjxl.git \
+                 libjxl-src; then
+              echo "Clone succeeded"
+              exit 0
+            fi
+            echo "Clone failed, cleaning up and retrying in 15s..."
+            rm -rf libjxl-src
+            sleep 15
+          done
+          echo "::error::Failed to clone libjxl after 3 attempts"
+          exit 1
 
       # ── Platform toolchain setup ───────────────────────────────────────
       - name: Install build tools (Linux)
@@ -67,7 +78,7 @@ jobs:
 
       - name: Install build tools (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake ninja nasm
+        run: brew install cmake ninja nasm llvm
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- libjxl clone 시 skcms submodule(`skia.googlesource.com`)의 간헐적 504 타임아웃 대응을 위해 3회 retry 로직 추가
- macOS Intel runner에서 `libclang.dylib`를 찾지 못하는 문제 해결을 위해 `llvm` brew 설치 추가

## Test plan
- [ ] `build-libjxl-prebuilt` workflow가 5개 플랫폼 모두에서 성공하는지 확인