### PR TITLE
fix(ci): fix bindgen install on Windows prebuilt workflow

### DIFF
--- a/.github/workflows/build-libjxl-prebuilt.yml
+++ b/.github/workflows/build-libjxl-prebuilt.yml
@@ -160,11 +160,18 @@ jobs:
         shell: bash
         run: echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
 
+      - name: Set LIBCLANG_PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LIBCLANG_PATH=C:/Program Files/LLVM/lib" >> $GITHUB_ENV
+
+      - name: Install bindgen-cli
+        shell: bash
+        run: cargo install bindgen-cli
+
       - name: Generate bindings.rs
         shell: bash
         run: |
-          cargo install bindgen-cli --locked --quiet 2>/dev/null || true
-
           SRC_INCLUDE="libjxl-src/lib/include"
           INSTALL_INCLUDE="libjxl-install/include"
 


### PR DESCRIPTION
## Summary
- `cargo install bindgen-cli` 에러 억제(`2>/dev/null || true`) 제거하여 실패 시 명확한 에러 출력
- bindgen-cli 설치를 별도 step으로 분리
- Windows runner에 `LIBCLANG_PATH` 설정 추가 (pre-installed LLVM 경로)

## Context
Run #22173731754에서 Windows만 실패: `bindgen: command not found` (cargo install이 조용히 실패)

## Test plan
- [ ] `build-libjxl-prebuilt` workflow Windows job 성공 확인