### PR TITLE
fix(ci): remove Git Bash link conflicting with MSVC link.exe

### DIFF
--- a/.github/workflows/build-libjxl-prebuilt.yml
+++ b/.github/workflows/build-libjxl-prebuilt.yml
@@ -92,6 +92,8 @@ jobs:
           echo "C:/Program Files/NASM" >> $GITHUB_PATH
           echo "CC=cl" >> $GITHUB_ENV
           echo "CXX=cl" >> $GITHUB_ENV
+          # Remove Git Bash's /usr/bin/link which conflicts with MSVC link.exe
+          rm -f /usr/bin/link
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Windows CI에서 `cargo install bindgen-cli` 실패 원인: Git Bash의 `/usr/bin/link`(Unix hard-link 명령)가 MSVC `link.exe`(링커) 대신 호출됨
- `Install build tools (Windows)` step에서 `/usr/bin/link` 제거하여 해결

## Error
```
/usr/bin/link: extra operand '...\build_script_build.exe'
error: linking with `link.exe` failed: exit code: 1
error: could not compile `quote` (build script)
```

## Test plan
- [ ] `build-libjxl-prebuilt` workflow Windows job 성공 확인