### PR TITLE
fix(ci): use API token for PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -470,9 +470,6 @@ jobs:
     name: Publish to PyPI
     needs: [build-python-wheels, build-python-sdist, verify-python-version, smoke-test-python]
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    environment: pypi
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -489,3 +486,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
PyPI는 reusable workflow에서의 trusted publishing(OIDC)을 지원하지 않음.
`release.yml` → `publish.yml` (workflow_call) 구조에서는 어떤 설정을 해도 OIDC 인증 실패.

API token 방식으로 변경.

## Required
- GitHub repo secrets에 `PYPI_API_TOKEN` 설정 필요